### PR TITLE
Fix misnamed sub element in <personGrp>

### DIFF
--- a/tei/kraus-die-letzten-tage-der-menschheit.xml
+++ b/tei/kraus-die-letzten-tage-der-menschheit.xml
@@ -1649,7 +1649,7 @@
             <persName>Ein sechster Wiener (IV/3)</persName>
           </person>
           <personGrp xml:id="rufe_4-3" sex="UNKNOWN">
-            <persName>Rufe (IV/3)</persName>
+            <name>Rufe (IV/3)</name>
           </personGrp>
           <person xml:id="das_oesterreichische_antlitz_4-3_und_5-55" sex="MALE">
             <persName>Das österreichische Antlitz (IV/3 und V/55)</persName>


### PR DESCRIPTION
In `kraus-die-letzten-tage-der-menschheit.xml`, for one `<personGrp>`, the sub element is called `<persName>`, while it is `<name>` for all others. This PR fixes this.