### PR TITLE
Update ludwig-der-erbfoerster.xml

### DIFF
--- a/tei/ludwig-der-erbfoerster.xml
+++ b/tei/ludwig-der-erbfoerster.xml
@@ -4985,7 +4985,7 @@
           </sp>
           <sp who="#weiler">
             <speaker>WEILER</speaker>
-            <stage>zeigt nach dein Fenster.</stage>
+            <stage>zeigt nach dem Fenster.</stage>
             <p>Da unten überm Lautenberge kommt eins herauf. Die Kibitze kreischten so ängstlich.
               Dacht's vorher. Es war zu schwül. – Ulrich, <stage>Kommt zu ihm.</stage> vor einer
               Stunde ist einer erschossen worden.</p>


### PR DESCRIPTION
fixed spelling mistake. See print: https://archive.org/details/dererbfrsterein00ludwgoog/page/n157/mode/1up